### PR TITLE
GitHub/CI: Fix displaying failed PR workflow runs that succeeded already

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## In progress
+- GitHub/CI: Fixed displaying failed workflow runs on pull requests
+  which succeeded afterward
 
 ## v0.1.0, 2025-02-20
 - Started using `GH_TOKEN` environment variable instead of `GITHUB_TOKEN`,


### PR DESCRIPTION
Previously `gh ci` displayed failed workflow runs on pull requests, because the processing only filtered by time range.
Now, failed workflow runs on pull requests will be checked against successful ones, and removed from display when not applicable.

