### PR TITLE
GitHub/Backup: Add wrapper around `github-backup`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ docs/_build
 __pycache__
 
 # Custom
+repositories
 slack_export

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   which succeeded afterward
 - GitHub/Bugs: Improved rendering of Markdown sections
 - GitHub/Bugs: Also consider labels `stale` and `type: Bug` as relevant
+- GitHub/Backup: Added wrapper around `github-backup`
 
 ## v0.1.0, 2025-02-20
 - Started using `GH_TOKEN` environment variable instead of `GITHUB_TOKEN`,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,6 +13,8 @@
 - GitHub/API: On errors, the JSON response includes the reason as an
   error message. However, it isn't displayed, yet.
 - Options: Make `limit=100` configurable? Is paging needed?
+- `github-backup` can do "Exceeded rate limit of 5000 requests;
+  waiting 77 seconds to reset". Do we also need it?
 
 ## Iteration +3
 - Data: Identify items with high conversation activity (comment frequency, etc.)

--- a/docs/guide/github.md
+++ b/docs/guide/github.md
@@ -51,6 +51,13 @@ rapporto gh attention --organization=python --timerange="2025W07"
 If you want to explore your personal repositories, please use the
 `--organization` option with your username, e.g. `--organization=AA-Turner`.
 
+### Backup
+Full GitHub project backup using [github-backup].
+```shell
+rapporto gh backup --all --pull-details --prefer-ssh --token="${GH_TOKEN}" --repository=kotori daq-tools
+```
+
 
 [GHA]: https://github.com/features/actions
+[github-backup]: https://pypi.org/project/github-backup/
 [PPP]: https://weekdone.com/resources/plans-progress-problems

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,13 @@ rapporto gh attention --organization=python --timerange="2025W07"
 ```
 :::
 
+:::{tab-item} Backup
+```{code-block} shell
+:caption: Full GitHub project backup using [github-backup].
+rapporto gh backup --all --pull-details --prefer-ssh --token="${GH_TOKEN}" --repository=kotori daq-tools
+```
+:::
+
 ::::
 
 ### Slack
@@ -82,6 +89,7 @@ and needs all support it can get. It is [managed on GitHub].
 [DWIM]: https://en.wikipedia.org/wiki/DWIM
 [GHA]: https://github.com/features/actions
 [GitHub]: https://en.wikipedia.org/wiki/GitHub
+[github-backup]: https://pypi.org/project/github-backup/
 [managed on GitHub]: https://github.com/tech-writing/rapporto
 [PPP]: https://weekdone.com/resources/plans-progress-problems
 [Slack]: https://en.wikipedia.org/wiki/Slack_(software)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords = [
   "github actions",
   "github activity",
   "github api",
+  "github backup",
   "github export",
   "information management",
   "markdown",
@@ -97,6 +98,7 @@ dependencies = [
   "click<9",
   "click-aliases<2",
   "dataclasses-json<1",
+  "github-backup<1",
   "importlib-metadata; python_version<'3.8'",
   "munch<5",
   "pueblo<1",
@@ -174,6 +176,7 @@ lint.select = [
 lint.extend-ignore = [
   # zip() without an explicit strict= parameter
   "B905",
+  "C408",   # Unnecessary `dict()` call (rewrite as a literal)
   "ERA001", # Found commented-out code.
   # df is a bad variable name. Be kinder to your future self.
   "PD901",

--- a/src/rapporto/github/backup.py
+++ b/src/rapporto/github/backup.py
@@ -1,0 +1,13 @@
+"""
+A small wrapper around `github-backup`.
+https://pypi.org/project/github-backup/
+"""
+
+import subprocess
+from shutil import which
+
+
+class GitHubBackup:
+    def run(self, args):
+        cmd = [which("github-backup")] + args
+        subprocess.check_call(cmd)  # noqa: S603

--- a/src/rapporto/github/cli.py
+++ b/src/rapporto/github/cli.py
@@ -7,6 +7,7 @@ from click_aliases import ClickAliasedGroup
 from rapporto.github.actions import GitHubActionsReport, MultiRepositoryInquiry
 from rapporto.github.activity import GitHubActivityReport
 from rapporto.github.attention import GitHubAttentionReport
+from rapporto.github.backup import GitHubBackup
 from rapporto.github.model import GitHubInquiry
 
 organization_option = click.option("--organization", "--org", type=str, required=False)
@@ -72,3 +73,22 @@ def attention(organization: t.Optional[str] = None, timerange: t.Optional[str] =
     inquiry = GitHubInquiry(organization=organization, created=timerange)
     report = GitHubAttentionReport(inquiry=inquiry)
     report.print()
+
+
+@cli.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    )
+)
+@click.pass_context
+def backup(ctx: click.Context):
+    """
+    Backup GitHub project.
+    """
+    backup = GitHubBackup()
+    try:
+        backup.run(ctx.args)
+    except Exception as ex:
+        click.echo(f"ERROR: {ex}", err=True)
+        raise SystemExit(2) from ex

--- a/tests/github/test_cli.py
+++ b/tests/github/test_cli.py
@@ -1,4 +1,11 @@
+import pytest
+
 from rapporto.cli import cli
+
+
+@pytest.fixture(autouse=True)
+def reset_environment(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
 
 
 def test_cli_ppp(cli_runner):
@@ -40,3 +47,19 @@ def test_cli_att(cli_runner):
     assert result.exit_code == 0
     assert "# Attention report 2025W08" in result.output
     assert "sphinx-design-elements" in result.output
+
+
+def test_cli_backup_unauthorized(cli_runner, capfd):
+    """
+    CLI test: Invoke `rapporto gh backup`.
+    """
+    result = cli_runner.invoke(
+        cli,
+        args="gh backup --repository=rapporto tech-writing",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+    assert "ERROR: Command" in result.output
+
+    out, err = capfd.readouterr()
+    assert "API request returned HTTP 401: Unauthorized" in err


### PR DESCRIPTION
## About

Wrapping [github-backup](https://pypi.org/project/github-backup) into `rapporto gh backup`.

- GH-18

## Documentation

- https://rapporto--22.org.readthedocs.build/guide/github.html#backup