### PR TITLE
Options: Add `--format=mrkdwn` option, improving Slack messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - GitHub/Backup: Added wrapper around `github-backup`
 - Options: Use `aika` for parsing time intervals.
   Also, rename command-line option `--timerange` to `--when`.
+- Options: Added `--format=mrkdwn` option, improving Slack messages
 
 ## v0.1.0, 2025-02-20
 - Started using `GH_TOKEN` environment variable instead of `GITHUB_TOKEN`,

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -31,4 +31,15 @@ or relative human-readable notations.
 - this month
 
 
+## Output options
+
+### Slack flavored Markdown
+
+The program can output two flavors of Markdown. Standard Markdown is default,
+while the [Slack `mrkdwn` format] can be produced using the `--format=mrkdwn`
+command-line option. Rapporto uses the [markdown-to-mrkdwn] package here.
+
+
 [aika]: https://pypi.org/project/aika/
+[markdown-to-mrkdwn]: https://pypi.org/project/markdown-to-mrkdwn/
+[Slack `mrkdwn` format]: https://api.slack.com/reference/surfaces/formatting#basic-formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dependencies = [
   "dataclasses-json<1",
   "github-backup<1",
   "importlib-metadata; python_version<'3.8'",
+  "markdown-to-mrkdwn<0.2",
   "munch<5",
   "pueblo<1",
   "python-dateutil<3",

--- a/src/rapporto/github/actions.py
+++ b/src/rapporto/github/actions.py
@@ -62,9 +62,6 @@ A report about GitHub Actions workflow runs that failed recently (now-{self.requ
 {mdc.render()}
         """.strip()  # noqa: E501
 
-    def print(self):
-        print(self.markdown)
-
 
 class GitHubActionsRequest:
     """

--- a/src/rapporto/github/activity.py
+++ b/src/rapporto/github/activity.py
@@ -1,6 +1,8 @@
 import dataclasses
+import io
 import logging
 import typing as t
+from contextlib import redirect_stdout
 from operator import attrgetter
 from textwrap import dedent
 
@@ -112,14 +114,18 @@ class GitHubActivityReport:
             f"comments: {item.comments_total}, files: {item.changed_files}, size: {item.code_size}"
         )
 
-    def print(self):
+    @property
+    def markdown(self) -> str:
         timerange = self.inquiry.created and f"for {self.inquiry.created}" or ""
-        print(f"# PPP report {timerange}")
-        # print("## Overview")
-        print(self.markdown_overview)
-        print()
-        print("*Top changes:*")
-        print(self.markdown_significant)
+        with redirect_stdout(io.StringIO()) as buffer:
+            print(f"# PPP report {timerange}")
+            # print("## Overview")
+            print(self.markdown_overview)
+            print()
+            print("*Top changes:*")
+            print(self.markdown_significant)
+        buffer.seek(0)
+        return buffer.read()
 
 
 @dataclass_json(undefined=Undefined.INCLUDE)

--- a/src/rapporto/github/attention.py
+++ b/src/rapporto/github/attention.py
@@ -110,6 +110,3 @@ A report about important items that deserve your attention, bugs first.
 Time range: {self.search.query_builder.timerange or "n/a"}
 {mdc.render()}
         """.strip()  # noqa: E501
-
-    def print(self):
-        print(self.markdown)

--- a/src/rapporto/util.py
+++ b/src/rapporto/util.py
@@ -1,3 +1,6 @@
+from markdown_to_mrkdwn import SlackMarkdownConverter
+
+
 def sanitize_title(title: str) -> str:
     """
     Strip characters that are unfortunate in Markdown link titles.
@@ -12,3 +15,10 @@ def goosefeet(text: str) -> str:
     if " " in text:
         return f'"{text}"'
     return text
+
+
+mrkdwn_converter = SlackMarkdownConverter()
+
+
+def to_mrkdwn(markdown: str) -> str:
+    return mrkdwn_converter.convert(markdown)


### PR DESCRIPTION
## About

Apparently, Slack may need special treatment for Markdown formatting? You can enable it going forward by using the `--format=mrkdwn` option.

## References

- GH-15
