### PR TITLE
GitHub/API: Use `updated` instead of `created` to get the whole picture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## In progress
 - Opsgenie: Added alert reporter. Thanks, @WalBah.
 - Opsgenie: Added time interval parsing using Aika, i.e. `--when` option
+- GitHub/API: Use `updated` instead of `created` to get the whole picture
 
 ## v0.2.0, 2025-02-24
 - GitHub/CI: Fixed displaying failed workflow runs on pull requests

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,8 +1,6 @@
 # Backlog
 
 ## Iteration +1
-- Slack: Support for `mrkdwn` output
-- GitHub: Process `created` + `updated`, not just `created`
 
 ## Iteration +2
 - GitHub/Actions: Currently lacks parameter `--when`
@@ -53,3 +51,5 @@
 - Refactoring: Spread GitHub modules along the feature axis
 - GitHub: Export conversations per GitHub Backup
 - Options: Parse time intervals using `aika`
+- Slack: Support for `mrkdwn` output
+- GitHub: Process `created` + `updated`, not just `created`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "aika>=0.2.1,<0.3",
+  "aika>=0.3.0,<0.4",
   "attrs<26",
   "click<9",
   "click-aliases<2",

--- a/src/rapporto/github/activity.py
+++ b/src/rapporto/github/activity.py
@@ -27,7 +27,7 @@ class GitHubActivityQueryBuilder(GitHubQueryBuilder):
 
     def query(self):
         self.add("org", self.inquiry.organization)
-        self.add("created", self.timerange)
+        self.add("updated", self.timeinterval.githubformat())
         self.add("author", self.inquiry.author)
 
 

--- a/src/rapporto/github/attention.py
+++ b/src/rapporto/github/attention.py
@@ -32,7 +32,7 @@ class GitHubAttentionQueryBuilder(GitHubQueryBuilder):
 
     def query(self):
         self.add("org", self.inquiry.organization)
-        self.add("created", self.timerange)
+        self.add("updated", self.timeinterval.githubformat())
         self.add("label", ",".join(map(goosefeet, self.labels)))
         self.add("state", "open")
 
@@ -107,6 +107,6 @@ class GitHubAttentionReport:
 # Attention report {self.inquiry.created or ""}
 
 A report about important items that deserve your attention, bugs first.
-Time range: {self.search.query_builder.timerange or "n/a"}
+Time range: {self.search.query_builder.timeinterval.githubformat() or "n/a"}
 {mdc.render()}
         """.strip()  # noqa: E501

--- a/src/rapporto/github/model.py
+++ b/src/rapporto/github/model.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from collections import OrderedDict
 from enum import Enum
 
-from aika import TimeIntervalParser
+from aika import TimeInterval, TimeIntervalParser
 from attrs import define
 
 logger = logging.getLogger(__name__)
@@ -55,11 +55,15 @@ class GitHubQueryBuilder:
         raise NotImplementedError("Needs to be implemented")
 
     @property
-    def timerange(self):
+    def timeinterval(self) -> TimeInterval:
         timerange_user = self.inquiry.created
-
         tr = TimeIntervalParser()
-        timerange_effective = tr.parse(timerange_user).mathformat()
+        return tr.parse(timerange_user)
+
+    @property
+    def timerange(self) -> str:
+        timerange_user = self.inquiry.created
+        timerange_effective = self.timeinterval.githubformat()
         logger.info(f'Using timerange: user="{timerange_user}" effective="{timerange_effective}"')
         return timerange_effective
 


### PR DESCRIPTION
## About
Improve querying the GitHub API towards more [DWIM](https://en.wikipedia.org/wiki/DWIM).
Activity and bugs are not just about _created_ events.

## References
- GH-13
- GH-23