### PR TITLE
GitHub/Actions: Fix deduplication for multiple workflows per repository

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## In progress
-- Shell/Notify: Add reference about caveats page to weekly report's preamble
+- Shell/Notify: Added reference about caveats page to weekly report's preamble
+- GitHub/Actions: Fixed deduplication for multiple different workflows per repository
 
 ## v0.6.0, 2025-03-11
 - Shell/Notify: Split root message into root+preamble, including links

--- a/src/rapporto/source/github/actions.py
+++ b/src/rapporto/source/github/actions.py
@@ -37,7 +37,7 @@ class GitHubActionsReport:
         seen = set()
         for run in self.runs_failed:
             # Filter duplicates.
-            key = f"{run.repository.full_name}-{run.head_branch}"
+            key = f"{run.repository.full_name}-{run.head_branch}-{run.name}"
             if key in seen:
                 continue
 
@@ -52,13 +52,13 @@ class GitHubActionsReport:
         """
         Find out if a given run has others that succeeded afterward.
         """
-        for pr in self.runs_pr_success:
+        for pr_run in self.runs_pr_success:
             if (
-                run.repository.full_name == pr.repository.full_name
-                and run.head_branch == pr.head_branch
+                run.repository.full_name == pr_run.repository.full_name
+                and run.head_branch == pr_run.head_branch
+                and run.name == pr_run.name
             ):
-                if pr.conclusion == "success":
-                    return True
+                return True
         return False
 
     @property


### PR DESCRIPTION
## Problem

A few items have not been displayed, when multiple different workflows belonged to the same repository.
