### PR TITLE
Goof: Make Slack wrapper use double tildes ~~ to encode a strikethrough

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## In progress
+- Goof: Made Slack wrapper use double tildes `~~` to encode a ~~strikethrough~~,
+  see also [Markdown, Strikethrough, and Slack].
 
 ## v0.6.1, 2025-04-01
 - Shell/Notify: Added reference about caveats page to weekly report's preamble
@@ -106,3 +108,6 @@
   ```shell
   rapporto github activity --organization=python --author=AA-Turner --when="2025-01-01..2025-01-31"
   ```
+
+
+[Markdown, Strikethrough, and Slack]: https://daringfireball.net/linked/2015/11/05/markdown-strikethrough-slack

--- a/src/rapporto/source/github/attention.py
+++ b/src/rapporto/source/github/attention.py
@@ -101,7 +101,7 @@ class GitHubAttentionReport:
             )
             link = f"[{title}]({item.html_url})"
             if is_closed:
-                line = f"- ~{link}~"
+                line = f"- ~~{link}~~"
             else:
                 line = f"- {link}"
             # line = f"- {link} {', '.join(labels)}"


### PR DESCRIPTION
## Problem

Apparently, Slack adjusted their markup syntax for encoding ~strikethrough~-formatted text. It needs to use two tilde characters `~~` now. Let's fix forward.

<img width="151" height="56" alt="image" src="https://github.com/user-attachments/assets/f06d1b87-54f9-41f9-9ee5-22ccb1bb91f1" />

## Notes

See also "Markdown, Strikethrough, and Slack" [1].

[1] https://daringfireball.net/linked/2015/11/05/markdown-strikethrough-slack