### PR TITLE
Dependencies: Adjust dependencies for `click-aliases`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In progress
+- Dependencies: Adjusted dependencies for `click-aliases`
 
 ## v0.6.2, 2026-04-25
 - Goof: Made Slack wrapper use double tildes `~~` to encode a ~~strikethrough~~,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dependencies = [
   "aika>=0.3.0,<0.4",
   "attrs<27",
   "click<9",
-  "click-aliases<2",
+  "click-aliases!=1.0.6,<2",
   "dataclasses-json<1",
   "furl<3",
   "github-backup<1",


### PR DESCRIPTION
## About
Exclude click-aliases v1.0.6.

## References
- https://github.com/click-contrib/click-aliases/issues/32